### PR TITLE
Support for geoip >= 1.4.7

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -7,6 +7,12 @@ unless have_func('iconv_open', 'iconv.h') or have_library('iconv', 'iconv_open',
 end
 
 if have_library('GeoIP', 'GeoIP_record_by_ipnum') and have_header('GeoIPCity.h')
+  # Defines HAVE_GEOIP_ADDR_TO_NUM
+  have_func('GeoIP_addr_to_num', 'GeoIP.h')
+
+  # Defines HAVE_GEOIP_NUM_TO_ADDR
+  have_func('GeoIP_num_to_addr', 'GeoIP.h')
+
   create_makefile('geoip')
 else
   abort("you must have geoip c library installed!")


### PR DESCRIPTION
- Maintains support for geoip <= 1.4.6
- GeoIP 1.4.7 promoted GeoIP_addr_to_num and GeoIP_num_to_addr to API
  methods, instead of pseudohiding them as _GeoIP_addr_to_num and
  _GeoIP_num_to_addr
- The signature of GeoIP_num_to_addr changed when it was promoted; it no
  longer accepts a GeoIP pointer as its first argument

Recommend releasing geoip 0.7.2 or 0.8.0 with this change, pretty please? ;) ;)
