### PR TITLE
Bug fix

### DIFF
--- a/geoip.c
+++ b/geoip.c
@@ -45,6 +45,9 @@ void rb_hash_sset(VALUE hash, const char *str, VALUE v) {
 static VALUE encode_to_utf8_and_return_rb_str(char *value) {
   char dst[BUFSIZ];
   size_t srclen = strlen(value);
+  if (value==NULL) {
+    return rb_str_new2("");
+  }
   size_t dstlen = srclen * 2;
 
   char * pIn = value;

--- a/geoip.c
+++ b/geoip.c
@@ -44,10 +44,10 @@ void rb_hash_sset(VALUE hash, const char *str, VALUE v) {
     https://github.com/Vagabond/erlang-iconv/blob/master/c_src/iconv_drv.c */
 static VALUE encode_to_utf8_and_return_rb_str(char *value) {
   char dst[BUFSIZ];
-  size_t srclen = strlen(value);
   if (value==NULL) {
     return rb_str_new2("");
   }
+  size_t srclen = strlen(value);
   size_t dstlen = srclen * 2;
 
   char * pIn = value;


### PR DESCRIPTION
db = GeoIP::City.new("GeoLiteCity.dat")
look_up = db.look_up("119.236.232.169")

Gives you a:

[BUG] Segmentation fault

Because region_name is empty for that IP. Those 2 commits fix that bug so that it returns an empty string. There are probably a better fix than returning an empty string but at least it fixes my problem.
